### PR TITLE
Purchase chickens and ducks

### DIFF
--- a/src/Actions/ChooseDuckHouse.cs
+++ b/src/Actions/ChooseDuckHouse.cs
@@ -6,27 +6,27 @@ using Trestlebridge.Models.Animals;
 
 namespace Trestlebridge.Actions
 {
-    public class ChooseChickenHouse
+    public class ChooseDuckHouse
     {
-        public static void CollectInput(Farm farm, ICluck chicken)
+        public static void CollectInput(Farm farm, IQuack duck)
         {
             Utils.Clear();
 
-            //Prints each chicken house facility available
-            for (int i = 0; i < farm.ChickenHouses.Count; i++)
+            //Prints each duck house facility available
+            for (int i = 0; i < farm.DuckHouses.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. Chicken House");
+                Console.WriteLine($"{i + 1}. Duck House");
             }
 
             Console.WriteLine();
 
-            Console.WriteLine($"Place the chicken where?");
+            Console.WriteLine($"Place the duck where?");
 
             Console.Write("> ");
             int choice = Int32.Parse(Console.ReadLine());
 
-            //Adds chicken to the particular chicken house selected
-            farm.ChickenHouses[choice-1].AddResource(chicken);
+            //Adds duck to the particular duck house selected
+            farm.DuckHouses[choice - 1].AddResource(duck);
 
             /*
                 Couldn't get this to work. Can you?

--- a/src/Actions/PurchaseStock.cs
+++ b/src/Actions/PurchaseStock.cs
@@ -9,7 +9,8 @@ namespace Trestlebridge.Actions {
         public static void CollectInput (Farm farm) {
             Console.WriteLine ("1. Cow");
             Console.WriteLine ("2. Ostrich");
-            Console.WriteLine ("3. Chicken");
+            Console.WriteLine ("6. Chicken");
+            Console.WriteLine ("7. Duck");
 
 
             Console.WriteLine ();
@@ -26,8 +27,11 @@ namespace Trestlebridge.Actions {
                 case 2:
                     ChooseGrazingField.CollectInput(farm, new Ostrich());
                     break;
-                case 3:
+                case 6:
                     ChooseChickenHouse.CollectInput(farm, new Chicken());
+                    break;
+                case 7:
+                    ChooseDuckHouse.CollectInput(farm, new Duck());
                     break;
                 default:
                     break;

--- a/src/Interfaces/IQuack.cs
+++ b/src/Interfaces/IQuack.cs
@@ -1,0 +1,8 @@
+namespace Trestlebridge.Interfaces
+{
+    public interface IQuack
+    {
+        double FeedPerDay { get; set; }
+        void Feed();
+    }
+}

--- a/src/Models/Animals/Duck.cs
+++ b/src/Models/Animals/Duck.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using Trestlebridge.Interfaces;
+
+namespace Trestlebridge.Models.Animals {
+    public class Duck : IResource, IQuack, IEggProducing, IFeatherProducing {
+
+        private Guid _id = Guid.NewGuid();
+        private int eggsProduced = 7;
+        private double feathersProduced = 0.5;
+
+        private string _shortId {
+            get {
+                return this._id.ToString().Substring(this._id.ToString().Length - 6);
+            }
+        }
+        
+        public string Type { get; } = "Duck";
+        public double FeedPerDay { get; set;} = 0.9;
+
+        // Methods
+        public void Feed () {
+            Console.WriteLine($"Duck {this._shortId} just ate {this.FeedPerDay}kg of feed");
+        }
+
+        public override string ToString () {
+            return $"Duck {this._shortId}. Quack!";
+        }
+
+        public int CollectEggs()
+        {
+            return eggsProduced;
+        }
+
+        public double GatherFeathers()
+        {
+            return feathersProduced;
+        }
+    }
+}

--- a/src/Models/Facilities/ChickenHouse.cs
+++ b/src/Models/Facilities/ChickenHouse.cs
@@ -28,7 +28,7 @@ namespace Trestlebridge.Models.Facilities {
 
         public void AddResource(List<ICluck> resources)
         {
-            throw new NotImplementedException();
+            chickens.AddRange(resources);
         }
 
         //Converting chickens in chicken house to a string that can be printed in the farm report

--- a/src/Models/Facilities/DuckHouse.cs
+++ b/src/Models/Facilities/DuckHouse.cs
@@ -25,8 +25,7 @@ namespace Trestlebridge.Models.Facilities {
 
         public void AddResource (List<IQuack> resources) 
         {
-            // TODO: implement this...
-            throw new NotImplementedException();
+            ducks.AddRange(resources);
         }
 
 

--- a/src/Models/Facilities/DuckHouse.cs
+++ b/src/Models/Facilities/DuckHouse.cs
@@ -5,12 +5,12 @@ using Trestlebridge.Interfaces;
 
 
 namespace Trestlebridge.Models.Facilities {
-    public class DuckHouse : IFacility<IFeed>
+    public class DuckHouse : IFacility<IQuack>
     {
         private int _capacity = 12;
         private Guid _id = Guid.NewGuid();
 
-        private List<IFeed> _animals = new List<IFeed>();
+        private List<IQuack> ducks = new List<IQuack>();
 
         public double Capacity {
             get {
@@ -18,13 +18,12 @@ namespace Trestlebridge.Models.Facilities {
             }
         }
 
-        public void AddResource (IFeed animal)
+        public void AddResource (IQuack resource)
         {
-            // TODO: implement this...
-            throw new NotImplementedException();
+            ducks.Add(resource);
         }
 
-        public void AddResource (List<IFeed> animals) 
+        public void AddResource (List<IQuack> resources) 
         {
             // TODO: implement this...
             throw new NotImplementedException();
@@ -36,8 +35,8 @@ namespace Trestlebridge.Models.Facilities {
             StringBuilder output = new StringBuilder();
             string shortId = $"{this._id.ToString().Substring(this._id.ToString().Length - 6)}";
 
-            output.Append($"Duck House {shortId} has {this._animals.Count} animals\n");
-            this._animals.ForEach(a => output.Append($"   {a}\n"));
+            output.Append($"Duck House {shortId} has {this.ducks.Count} ducks\n");
+            this.ducks.ForEach(a => output.Append($"   {a}\n"));
 
             return output.ToString();
         }

--- a/src/Models/Facilities/DuckHouse.cs
+++ b/src/Models/Facilities/DuckHouse.cs
@@ -18,6 +18,7 @@ namespace Trestlebridge.Models.Facilities {
             }
         }
 
+        //Adding ducks to duck house
         public void AddResource (IQuack resource)
         {
             ducks.Add(resource);

--- a/src/Models/Farm.cs
+++ b/src/Models/Farm.cs
@@ -28,6 +28,9 @@ namespace Trestlebridge.Models
                 case "Chicken":
                     ChickenHouses[index].AddResource((ICluck)resource);
                     break;
+                case "Duck":
+                    DuckHouses[index].AddResource((IQuack)resource);
+                    break;
                 case "Sunflower":
                     NaturalFields[index].AddResource((ICompostProducing)resource);
                     break;


### PR DESCRIPTION
What I did:
- Modified a line of code in ChooseChickenHouse and ChooseDuckHouse files.
- ChooseDuckHouse.cs and ChooseChickenHouse.cs allows for appropriate fields to be viewed for each animal
- AddResource() in DuckHouse.cs and ChickenHouse.cs adds the appropriate animal to each appropriate facility

What you should see:
- Purchase chicken, place in a chicken house, re route to main menu. View purchased chickens in appropriate facility/chicken house in Farm report
- Purchase duck, place in a duck house, re route to main menu. View purchased ducks in appropriate facility/duck house in Farm report
- Users can only see chicken house facility options when purchasing a chicken and only duck house facility options when purchasing a duck